### PR TITLE
Error: name 'final' is not defined problem fixed

### DIFF
--- a/day50-multiple-linear-regression/multiple_linear_regression.ipynb
+++ b/day50-multiple-linear-regression/multiple_linear_regression.ipynb
@@ -364,11 +364,13 @@
         "y = np.linspace(-5, 5, 10)\n",
         "xGrid, yGrid = np.meshgrid(y, x)\n",
         "\n",
+       "final = np.vstack((xGrid.ravel().reshape(1,100),yGrid.ravel().reshape(1,100))).T"
+        "\n",
         "z_final = lr.predict(final).reshape(10,10)\n",
         "\n",
         "z = z_final\n",
         "\n",
-        "final = np.vstack((xGrid.ravel().reshape(1,100),yGrid.ravel().reshape(1,100))).T"
+       
       ],
       "execution_count": 224,
       "outputs": []


### PR DESCRIPTION
### Sir, the final variable was not found when run it. Because, we assigning the final variable in the next line. Instead, we used it in previous line. 

Code:
```
z_final = lr.predict(   final  ).reshape(10,10)
z = z_final
final = np.vstack((xGrid.ravel().reshape(1,100),yGrid.ravel().reshape(1,100))).T
```